### PR TITLE
reducer fixes, menu buttons, hide content

### DIFF
--- a/app/api/album_routes.py
+++ b/app/api/album_routes.py
@@ -7,5 +7,7 @@ album_routes = Blueprint('albums', __name__)
 @album_routes.route('/<int:albumId>')
 def get_album(albumId):
     album = Album.query.get(albumId)
+    if not album:
+        return {'no_album': 'none found'}
 
     return album.to_dict()

--- a/app/api/artist_routes.py
+++ b/app/api/artist_routes.py
@@ -7,5 +7,6 @@ artist_routes = Blueprint('artists', __name__)
 @artist_routes.route('/<int:artistId>')
 def get_artist(artistId):
     artist = Artist.query.get(artistId)
-
+    if not artist:
+        return {'none': 'not found'}
     return artist.to_dict()

--- a/app/api/user_routes.py
+++ b/app/api/user_routes.py
@@ -164,6 +164,7 @@ def load_library(userId):
 @login_required
 def delete_library_album(albumId):
     value = request.json
+    print('\n \n ', value, ' \n \n' )
     library = Library.query.filter(Library.user_id == value['userId']).first()
     user_album = Album.query.get(albumId)
     index = 0

--- a/react-app/src/components/AlbumPage/AlbumPage.css
+++ b/react-app/src/components/AlbumPage/AlbumPage.css
@@ -22,3 +22,10 @@
   display: flex;
   margin: 20px;
 }
+
+#album{
+  display: flex;
+  align-items: center;
+  flex-direction: row;
+  gap: 15px;
+}

--- a/react-app/src/components/AlbumPage/index.js
+++ b/react-app/src/components/AlbumPage/index.js
@@ -3,9 +3,13 @@ import { useSelector, useDispatch } from "react-redux";
 import { Link, useParams } from "react-router-dom";
 import { load_album } from "../../store/album";
 import { SongsList } from "../songList";
-import { add_Library_Album } from "../../store/library";
+import { add_Library_Album, delete_LibraryAlbum } from "../../store/library";
 import "./AlbumPage.css";
 import { PlayButton } from "../AudioPlayer/PlayButton";
+import Dropdown from "rc-dropdown";
+import Menu, { Item as MenuItem } from "rc-menu";
+import "rc-dropdown/assets/index.css";
+import { FaEllipsisH} from "react-icons/fa";
 
 export const AlbumPage = () => {
   let { albumId } = useParams();
@@ -18,9 +22,15 @@ export const AlbumPage = () => {
 
   const albumObj = useSelector((state) => state.albumReducer);
   const userId = useSelector((state) => state.session.user.id)
-  console.log(userId);
 
-  console.log(albumObj?.album?.songs?.dict);
+  const menu = (
+    <Menu id='user-menu-style'>
+      <MenuItem id="testing_menu" onClick={() => dispatch(add_Library_Album(userId, albumId))} key="1">Add to Library</MenuItem>
+      <MenuItem id="testing_menu" onClick={() => dispatch(delete_LibraryAlbum(userId, albumId ))} key="2">Remove from Library</MenuItem>
+    </Menu>
+  );
+
+  // console.log(albumObj?.album?.songs?.dict);
   let songs = albumObj?.album?.songs?.dict;
 
   return (
@@ -31,7 +41,6 @@ export const AlbumPage = () => {
         </div>
         <div>
           <h4>ALBUM</h4>
-          <button onClick={(() => dispatch(add_Library_Album(userId, albumId)))}>Add Album to Library</button>
           <h1>{albumObj?.album?.name}</h1>
           <img className="artistIcon" src={albumObj?.album?.artist_image} />
           <Link to={`/artists/${albumObj?.album?.artist_id}`}>
@@ -40,9 +49,20 @@ export const AlbumPage = () => {
         </div>
       </div>
       <br />
-      <div classname="page-buttons">
-      <PlayButton type={"albums"} mediaId={albumId} />
+      {albumObj.album.id && <>
+      <div className="page-buttons" id='album'>
+        <PlayButton type={"albums"} mediaId={albumId} />
+        <div >
+            <Dropdown
+              trigger={["click"]}
+              overlay={menu}
+              animation="slide-up"
+            >
+              <p id='icon-color' style={{width: 150}}><FaEllipsisH /></p>
+            </Dropdown>
+          </div>
       </div>
+      </>}
       <hr />
       <br />
       <SongsList songProp={songs} />

--- a/react-app/src/components/ArtistPage/ArtistPage.css
+++ b/react-app/src/components/ArtistPage/ArtistPage.css
@@ -2,3 +2,7 @@
     border-radius: 50%;
     object-fit: cover;
 }
+
+#artist-menu{
+    margin-left: 30px;
+}

--- a/react-app/src/components/ArtistPage/index.js
+++ b/react-app/src/components/ArtistPage/index.js
@@ -5,44 +5,73 @@ import { load_artist } from "../../store/artist";
 import { ContentList } from "../ContentList";
 import { SongsList } from "../songList";
 import "./ArtistPage.css";
-import { add_Library_Artist } from "../../store/library";
+import { add_Library_Artist, delete_LibraryArtist } from "../../store/library";
+import Dropdown from "rc-dropdown";
+import Menu, { Item as MenuItem } from "rc-menu";
+import "rc-dropdown/assets/index.css";
+import { FaEllipsisH } from "react-icons/fa";
 
 export const ArtistPage = () => {
-    const { artistId } = useParams();
-    const dispatch = useDispatch();
+  const { artistId } = useParams();
+  const dispatch = useDispatch();
 
+  useEffect(() => {
+    dispatch(load_artist(artistId));
+  }, [dispatch]);
 
-    useEffect(() => {
-        dispatch(load_artist(artistId));
-      }, [dispatch]);
+  const artistObj = useSelector((state) => state?.artistReducer?.artist);
+  const userId = useSelector((state) => state.session.user.id);
+  let albums = artistObj?.albums?.dict;
+  let songs = artistObj?.songs?.dict;
 
-      const artistObj = useSelector((state) => state?.artistReducer?.artist);
-      const userId = useSelector((state) => state.session.user.id)
-      let albums = artistObj?.albums?.dict;
-      let songs = artistObj?.songs?.dict;
+  const menu = (
+    <Menu id="user-menu-style">
+      <MenuItem
+        id="testing_menu"
+        onClick={() => dispatch(add_Library_Artist(userId, artistId))}
+        key="1"
+      >
+        Add Artist to Library
+      </MenuItem>
+      <MenuItem
+        id="testing_menu"
+        onClick={() => dispatch(delete_LibraryArtist(userId, artistId))}
+        key="2"
+      >
+        Remove Artist from Library
+      </MenuItem>
+    </Menu>
+  );
 
+  return (
+    <>
+      <div className="albumTop">
+        <div>
+          <img className="albumImage artistImage" src={artistObj?.image} />
+        </div>
+        <div>
+          <h1>{artistObj?.name}</h1>
 
-    return (
-        <>
-            <div className="albumTop">
-                <div>
-                    <img className="albumImage artistImage" src={artistObj?.image} />
-                </div>
-                <div>
-                    <h1>{artistObj?.name}</h1>
-                    <button onClick={(() => dispatch(add_Library_Artist(userId, artistObj.id)))}>Add artist to library</button>
-                    {/* <img className="artistIcon" src={artistObj?.image} /> */}
-                    {/* <Link to={`/albums/${artistObj?.id}`}>
+          {/* <img className="artistIcon" src={artistObj?.image} /> */}
+          {/* <Link to={`/albums/${artistObj?.id}`}>
                         {artistObj?.album?.artist}
                     </Link> */}
-                </div>
-            </div>
-            <br />
-            <hr />
-            <br />
-            <h2>Popular</h2>
-            <SongsList songProp={songs?.splice(0, 5)} />
-            {albums && <ContentList array={albums} heading={'Albums'}/>}
-        </>
-    )
-}
+        </div>
+      </div>
+      {artistObj?.id &&
+      <div id='artist-menu'>
+        <Dropdown trigger={["click"]} overlay={menu} animation="slide-up">
+          <p id="icon-color" style={{ width: 150 }}>
+            <FaEllipsisH />
+          </p>
+        </Dropdown>
+      </div> }
+      <br />
+      <hr />
+      <br />
+      <h2>{artistObj?.id ? 'Popular' : ''}</h2>
+      <SongsList songProp={songs?.splice(0, 5)} />
+      {albums && <ContentList array={albums} heading={"Albums"} />}
+    </>
+  );
+};

--- a/react-app/src/components/NavBar.js
+++ b/react-app/src/components/NavBar.js
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { useSelector, useDispatch } from "react-redux";
-import { NavLink } from "react-router-dom";
+import { NavLink, Link } from "react-router-dom";
 import { load_Playlists } from "../store/playlists";
 import Modal from "react-modal";
 import { CreatePlaylistForm } from "./CreatePlaylistForm";
@@ -61,9 +61,11 @@ const NavBar = () => {
   return (
     <>
       <nav id="sidebar">
+        <Link id='spot-icon' to='/'>
         <h2>
           <FaSpotify /> Spotify
         </h2>
+        </Link>
         <div className="navbar-playlist">
         <ul>
           {/* <li>

--- a/react-app/src/components/ProfilePage/index.js
+++ b/react-app/src/components/ProfilePage/index.js
@@ -73,7 +73,7 @@ export const ProfilePage = () => {
     }).length > 0) ? 'Following' : 'Follow'}</h4>
         <div style={{ margin: 20 }}>
           {/* <div style={{ height: 100 }} /> */}
-          <div id='idk2'>
+          <div id='menu-marg'>
             <Dropdown
               trigger={["click"]}
               overlay={menu}

--- a/react-app/src/components/ProfilePage/menu.css
+++ b/react-app/src/components/ProfilePage/menu.css
@@ -19,7 +19,7 @@
     background-color: #282828;
     border-radius: 4px;
     border: none;
-    width: 150px;
+    width: 170px;
     height: 75px;
     box-shadow: 0 16px 24px rgb(0 0 0 / 30%), 0 6px 8px rgb(0 0 0 / 20%);
 }
@@ -38,6 +38,6 @@
     margin:0
 }
 
-#idk2{
+#menu-marg{
     margin-top: 7px;
 }

--- a/react-app/src/components/viewOnePlayList/CompoundAlbumImage.css
+++ b/react-app/src/components/viewOnePlayList/CompoundAlbumImage.css
@@ -13,3 +13,9 @@
   width: 96px;
 
 }
+
+.page-buttons.playlist{
+  display: flex;
+  align-items: center;
+  gap: 15px;
+}

--- a/react-app/src/components/viewOnePlayList/ViewOnePlaylist.js
+++ b/react-app/src/components/viewOnePlayList/ViewOnePlaylist.js
@@ -1,5 +1,5 @@
 import { useDispatch, useSelector } from "react-redux";
-import { add_Library_Playlist } from "../../store/library";
+import { add_Library_Playlist, delete_LibraryPlaylist } from "../../store/library";
 // import { one_Playlists, delete_Playlist } from "../../store/playlists";
 import {
   useHistory,
@@ -7,10 +7,15 @@ import {
 } from "react-router-dom";
 import UserPlaylistsEdit from "../userPlaylists/EditPlayListForm";
 import { SongsList } from "../songList";
-import { delete_Playlist, getOnePlaylist, load_Playlists } from "../../store/playlists";
+import { add_Playlist, delete_Playlist, getOnePlaylist, load_Playlists } from "../../store/playlists";
 import { CompoundAlbumImage } from "./CompoundAlbumImage";
 import { useEffect } from "react";
 import { PlayButton } from "../AudioPlayer/PlayButton";
+import Dropdown from "rc-dropdown";
+import Menu, { Item as MenuItem } from "rc-menu";
+import "rc-dropdown/assets/index.css";
+import { FaEllipsisH} from "react-icons/fa";
+
 
 const ViewOnePlaylist = () => {
   const dispatch = useDispatch();
@@ -22,12 +27,19 @@ const ViewOnePlaylist = () => {
   const { id } = useSelector((state) => state.session.user);
 
 
-  const currPlaylist = useSelector((state) => state?.playListReducer.currentPlaylist)
 
+  const currPlaylist = useSelector((state) => state?.playListReducer.currentPlaylist)
+  const menu = (
+    <Menu id='user-menu-style'>
+      <MenuItem id="testing_menu" onClick={() => dispatch(add_Library_Playlist(id, currPlaylist?.id ))} key="1">Add Playlist to Library</MenuItem>
+      <MenuItem id="testing_menu" onClick={() => dispatch(delete_LibraryPlaylist(id, currPlaylist?.id ))} key="2">Remove Playlist from Library</MenuItem>
+    </Menu>
+  );
   const playlistProp = currPlaylist?.songs?.dict;
 
   const handleDelete = () => {
     dispatch(delete_Playlist({ userId: id, playlistId: currPlaylist.id }));
+    dispatch(delete_LibraryPlaylist(id, currPlaylist?.id))
     dispatch(load_Playlists(id));
     return history.push("/");
   };
@@ -47,10 +59,6 @@ const ViewOnePlaylist = () => {
           {imag}
         </div>
         <div>
-          <h4>PLAYLIST</h4>
-          {currPlaylist?.id &&
-          <button onClick={(() => dispatch(add_Library_Playlist(id, playlistId)))}>Add to library</button>
-           }
           <h1>{currPlaylist?.name}</h1>
           <p>{currPlaylist?.description}</p>
           {/* <Link to={`/users/${currPlaylist?.user_id}`}>
@@ -59,8 +67,20 @@ const ViewOnePlaylist = () => {
         </div>
       </div>
       <br />
-      <div className='page-buttons'>
+
+      <div className='page-buttons playlist'>
+          {currPlaylist?.id && <>
           <PlayButton mediaId={id} type={'playlists'}/>
+          <div >
+            <Dropdown
+              trigger={["click"]}
+              overlay={menu}
+              animation="slide-up"
+            >
+              <p id='icon-color' style={{width: 150}}><FaEllipsisH /></p>
+            </Dropdown>
+          </div>
+            </>}
       {currPlaylist?.user_id == id && (
         <>
           <UserPlaylistsEdit playList={currPlaylist} />

--- a/react-app/src/index.css
+++ b/react-app/src/index.css
@@ -244,6 +244,7 @@ body,
   background-color: inherit;
   padding: 0;
   margin: 0;
+  cursor: pointer;
 }
 
 .button-white:hover {
@@ -270,4 +271,8 @@ body,
   width: 100%;
   overflow-y: scroll;
   height: 300px;
+}
+
+#spot-icon{
+  text-decoration: none;
 }

--- a/react-app/src/store/library.js
+++ b/react-app/src/store/library.js
@@ -125,22 +125,22 @@ export const add_Library_Album = (userId, albumId) => async dispatch => {
 }
 
 
-const deleteLibraryAlbum = (libraryId, albumId) => {
+const deleteLibraryAlbum = (userId, albumId) => {
     return {
         type: DELETE_LIBRARY_ALBUM,
         albumId,
-        libraryId
+        userId
     }
 }
 
-export const delete_LibraryAlbum = (libraryId, albumId) => async dispatch => {
+export const delete_LibraryAlbum = (userId, albumId) => async dispatch => {
     const response = await fetch(`/api/users/library/${albumId}/delete`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ libraryId, albumId }),
+        body: JSON.stringify({ userId, albumId }),
     })
     const data = await response.json()
-    dispatch(deleteLibraryAlbum(libraryId, albumId))
+    dispatch(deleteLibraryAlbum(userId, albumId))
 }
 
 const loadLibrary = (data) => {
@@ -171,7 +171,7 @@ const libraryReducer = (state = {}, action) => {
             return newState
         case DELETE_LIBRARY_ALBUM:
             newState = { ...state }
-            newState.album = newState.album.filter(ele => ele.id !== action.albumId);
+            newState.albums = newState.albums.filter(ele => ele.id !== action.albumId);
             return newState
         case DELETE_LIBRARY_ARTIST:
             newState = { ...state }
@@ -179,8 +179,7 @@ const libraryReducer = (state = {}, action) => {
             return newState
         case DELETE_LIBRARY_PLAYLIST:
             newState = { ...state }
-            newState.playlist = newState.playlist.filter(ele => ele.id !== action.playlistId);
-
+            newState.playlists = newState.playlists.filter(ele => ele.id !== action.playlistId);
             return newState
         case DELETE_LIBRARY_SONG:
             newState = { ...state }

--- a/react-app/src/store/playlists.js
+++ b/react-app/src/store/playlists.js
@@ -57,8 +57,8 @@ export const delete_Playlist =
         playlistId,
       }),
     });
-    console.log(userId, playlistId, "ids in the backend");
     const { deleted } = await response.json();
+ 
     dispatch(deletePlaylist(deleted));
     return deleted;
   };
@@ -189,9 +189,9 @@ const playListReducer = (state = initialState, action) => {
     case DELETE_FROM_PLAYLIST:
       newState = { ...state };
       newState.playLists[action.updatedPlaylist.id] = action.updatedPlaylist;
-      console.log(action.updatedPlaylist.id);
-      console.log("==========================");
-      console.log(newState);
+      // console.log(action.updatedPlaylist.id);
+      // console.log("==========================");
+      // console.log(newState);
       return newState;
     case GET_ONE_PLAYLIST:
       newState = { ...state };


### PR DESCRIPTION
new changes being pushed: added more return statements to get routes if item not found to avert console error, added artist/playlist/album menu buttons that has options to add and remove from library, made spotify icon on top left clickable to return to home, fixed playlists so that when you delete a playlist it is deleted from both your library and playlists bar on the left side, also made it that if you type in the url for example '/albums/27' it will not show the menu or play button for album/artist/playlists, if the button is showing and clicked on it throws errors. so it should only appear now if there is actual content found in database